### PR TITLE
Static ice shelf initialize

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -277,7 +277,8 @@ type, public :: MOM_control_struct ; private
   type(time_type) :: dtbt_reset_interval !< A time_time representation of dtbt_reset_period.
   type(time_type) :: dtbt_reset_time !< The next time DTBT should be calculated.
   real, dimension(:,:), pointer :: frac_shelf_h => NULL() !< fraction of total area occupied
-                                     !! by ice shelf [nondim]
+  !! by ice shelf [nondim]
+  real, dimension(:,:), pointer :: mass_shelf => NULL() !< Mass of ice shelf [R Z ~> kg m-2]
   real, dimension(:,:,:), pointer :: &
     h_pre_dyn => NULL(), &      !< The thickness before the transports [H ~> m or kg m-2].
     T_pre_dyn => NULL(), &      !< Temperature before the transports [degC].
@@ -1703,7 +1704,7 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
 
   ! Initial state on the input index map
   real, allocatable, dimension(:,:,:) :: u_in, v_in, h_in
-  real, allocatable, dimension(:,:), target :: frac_shelf_in
+  real, allocatable, dimension(:,:), target :: frac_shelf_in, mass_shelf_in
   real, allocatable, dimension(:,:,:), target :: T_in, S_in
   type(ocean_OBC_type), pointer :: OBC_in => NULL()
   type(sponge_CS), pointer :: sponge_in_CSp => NULL()
@@ -2457,14 +2458,18 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
       ! for legacy reasons. The actual ice shelf diag CS is internal to the ice shelf
       call initialize_ice_shelf(param_file, G_in, Time, ice_shelf_CSp, diag_ptr)
       allocate(frac_shelf_in(G_in%isd:G_in%ied, G_in%jsd:G_in%jed), source=0.0)
+      allocate(mass_shelf_in(G_in%isd:G_in%ied, G_in%jsd:G_in%jed), source=0.0)
       allocate(CS%frac_shelf_h(isd:ied, jsd:jed), source=0.0)
-      call ice_shelf_query(ice_shelf_CSp,G,CS%frac_shelf_h)
+      allocate(CS%mass_shelf(isd:ied, jsd:jed), source=0.0)
+      call ice_shelf_query(ice_shelf_CSp,G,CS%frac_shelf_h, CS%mass_shelf)
+      CS%mass_shelf = CS%mass_shelf*US%kg_m3_to_R*US%m_to_Z
       ! MOM_initialize_state is using the  unrotated metric
       call rotate_array(CS%frac_shelf_h, -turns, frac_shelf_in)
+      call rotate_array(CS%mass_shelf, -turns, mass_shelf_in)
       call MOM_initialize_state(u_in, v_in, h_in, CS%tv, Time, G_in, GV, US, &
           param_file, dirs, restart_CSp, CS%ALE_CSp, CS%tracer_Reg, &
           sponge_in_CSp, ALE_sponge_in_CSp, oda_incupd_in_CSp, OBC_in, Time_in, &
-          frac_shelf_h=frac_shelf_in)
+          frac_shelf_h=frac_shelf_in, mass_shelf = mass_shelf_in)
     else
       call MOM_initialize_state(u_in, v_in, h_in, CS%tv, Time, G_in, GV, US, &
           param_file, dirs, restart_CSp, CS%ALE_CSp, CS%tracer_Reg, &
@@ -2507,16 +2512,18 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
       deallocate(S_in)
     endif
     if (use_ice_shelf) &
-      deallocate(frac_shelf_in)
+      deallocate(frac_shelf_in,mass_shelf_in)
   else
     if (use_ice_shelf) then
       call initialize_ice_shelf(param_file, G, Time, ice_shelf_CSp, diag_ptr)
       allocate(CS%frac_shelf_h(isd:ied, jsd:jed), source=0.0)
-      call ice_shelf_query(ice_shelf_CSp,G,CS%frac_shelf_h)
+      allocate(CS%mass_shelf(isd:ied, jsd:jed), source=0.0)
+      call ice_shelf_query(ice_shelf_CSp,G,CS%frac_shelf_h, CS%mass_shelf)
+      CS%mass_shelf = CS%mass_shelf*US%kg_m3_to_R*US%m_to_Z
       call MOM_initialize_state(CS%u, CS%v, CS%h, CS%tv, Time, G, GV, US, &
           param_file, dirs, restart_CSp, CS%ALE_CSp, CS%tracer_Reg, &
           CS%sponge_CSp, CS%ALE_sponge_CSp,CS%oda_incupd_CSp, CS%OBC, Time_in, &
-          frac_shelf_h=CS%frac_shelf_h)
+          frac_shelf_h=CS%frac_shelf_h, mass_shelf=CS%mass_shelf)
     else
       call MOM_initialize_state(CS%u, CS%v, CS%h, CS%tv, Time, G, GV, US, &
           param_file, dirs, restart_CSp, CS%ALE_CSp, CS%tracer_Reg, &
@@ -2524,8 +2531,10 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
     endif
   endif
 
-  if (use_ice_shelf .and. CS%debug) &
+  if (use_ice_shelf .and. CS%debug) then
     call hchksum(CS%frac_shelf_h, "MOM:frac_shelf_h", G%HI, haloshift=0)
+    call hchksum(CS%mass_shelf, "MOM:mass_shelf", G%HI, haloshift=0)
+  endif
 
   call cpu_clock_end(id_clock_MOM_init)
   call callTree_waypoint("returned from MOM_initialize_state() (initialize_MOM)")

--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -2034,11 +2034,12 @@ subroutine update_shelf_mass(G, US, CS, ISS, Time)
 end subroutine update_shelf_mass
 
 !> Save the ice shelf restart file
-subroutine ice_shelf_query(CS, G, frac_shelf_h)
+subroutine ice_shelf_query(CS, G, frac_shelf_h, mass_shelf)
   type(ice_shelf_CS),         pointer    :: CS !< ice shelf control structure
   type(ocean_grid_type), intent(in)      :: G  !< A pointer to an ocean grid control structure.
-  real, optional, dimension(SZI_(G),SZJ_(G))  :: frac_shelf_h !<
-                                      !< Ice shelf area fraction [nodim].
+  real, optional, dimension(SZI_(G),SZJ_(G))  :: frac_shelf_h !< Ice shelf area fraction [nodim].
+  real, optional, dimension(SZI_(G),SZJ_(G))  :: mass_shelf !<Ice shelf mass [RZ -> kg m-2]
+
 
   integer :: i, j
 
@@ -2046,6 +2047,13 @@ subroutine ice_shelf_query(CS, G, frac_shelf_h)
     do j=G%jsd,G%jed ; do i=G%isd,G%ied
       frac_shelf_h(i,j) = 0.0
       if (G%areaT(i,j)>0.) frac_shelf_h(i,j) = CS%ISS%area_shelf_h(i,j) / G%areaT(i,j)
+    enddo ; enddo
+  endif
+
+  if (present(mass_shelf)) then
+    do j=G%jsd,G%jed ; do i=G%isd,G%ied
+      mass_shelf(i,j) = 0.0
+      if (G%areaT(i,j)>0.) mass_shelf(i,j) = CS%ISS%mass_shelf(i,j)
     enddo ; enddo
   endif
 


### PR DESCRIPTION
Hydrostatic initialization under ice shelf cavities

 - Iteratively solve for the initial surface displacement under ice shelf cavities based on the applied pressure using the initial guess layered T/S profile above the level of the ice shelf displacement. 
 - This option should deprecate the use of TRIM_IC_FOR_P_SURF 
 - Turing off both TRIM_IC_FOR_P_SURF and DEPRESS_INITIAL_SURFACE to activate this option.
 - Existing ice shelf implementations (e.g. ISOMIP) should be reconfigured to use this option.
 - This option was tested using https://github.com/MJHarrison-GFDL/MOM6-IceShelf-examples/tree/47e13d7e9
  where the model was found to produce a more balanced initialization.